### PR TITLE
Let CI pipeline take care of firmware builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@main
       - name: Build firmware
         run: |
-          apt install arm-none-eabi-gcc
+          sudo apt install -y arm-none-eabi-gcc
           git clone https://github.com/raspberrypi/pico-sdk --recurse-submodules
           cd ./firmware
           mkdir build && cd build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
       - name: Clone pico-sdk dependency
         run: |
           git clone https://github.com/raspberrypi/pico-sdk --recurse-submodules
+          git reset --hard 2e6142b
       - name: Build firmware
         run: |
           arm-none-eabi-gcc --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,11 +8,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
+      - name: arm-none-eabi-gcc-action
+        uses: carlosperate/arm-none-eabi-gcc-action@v1
       - name: Clone pico-sdk dependency
         run: |
           git clone https://github.com/raspberrypi/pico-sdk --recurse-submodules
       - name: Build firmware
-        uses: carlosperate/arm-none-eabi-gcc-action@v1
         run: |
           arm-none-eabi-gcc --version
           cd ./firmware

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
-      - name: arm-none-eabi-gcc-action
+      - name: Setup arm-none-eabi-gcc
         uses: carlosperate/arm-none-eabi-gcc-action@v1
+      - name: Setup ninja
+        uses: seanmiddleditch/gha-setup-ninja@master
       - name: Clone pico-sdk dependency
         run: |
           git clone https://github.com/raspberrypi/pico-sdk --recurse-submodules

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,7 @@ jobs:
         uses: actions/checkout@main
       - name: Build firmware
         run: |
-          pwd
-          ls -al
+          apt install arm-none-eabi-gcc
           git clone https://github.com/raspberrypi/pico-sdk --recurse-submodules
           cd ./firmware
           mkdir build && cd build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,11 @@ jobs:
         uses: carlosperate/arm-none-eabi-gcc-action@v1
       - name: Setup ninja
         uses: seanmiddleditch/gha-setup-ninja@master
-      - name: Clone pico-sdk dependency
+      - name: Clone pico-sdk dependency (pinned versions of pico-sdk and tinyusb)
         run: |
           git clone https://github.com/raspberrypi/pico-sdk --recurse-submodules
-          cd pico-sdk && git reset --hard 2e6142b && cd ..
+          cd pico-sdk && sudo git reset --hard 2e6142b && cd ..
+          cd pico-sdk/lib/tinyusb && sudo git checkout 0.14.0 && cd ../../..
       - name: Build firmware
         run: |
           arm-none-eabi-gcc --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Clone pico-sdk dependency (pinned versions of pico-sdk and tinyusb)
         run: |
           git clone https://github.com/raspberrypi/pico-sdk --recurse-submodules
-          cd pico-sdk && sudo git reset --hard 2e6142b && cd ..
-          cd pico-sdk/lib/tinyusb && sudo git checkout 0.14.0 && cd ../../..
+          cd pico-sdk && sudo git checkout tags/1.5.1 && cd ..
+          cd pico-sdk/lib/tinyusb && sudo git checkout 0.16.0 && cd ../../..
       - name: Build firmware
         run: |
           arm-none-eabi-gcc --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+name: Build gbinterceptor
+on:
+  push:
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Build
+        run: |
+          echo "Test"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,12 @@ jobs:
       - name: Install arm-none-eabi-gcc
         run: |
           wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2
+          sudo tar xjf gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 -C ./gcc-arm-none-eabi
+          sudo ln -s ./gcc-arm-none-eabi/bin/arm-none-eabi-gcc /usr/bin/arm-none-eabi-gcc 
+          sudo ln -s ./gcc-arm-none-eabi/bin/arm-none-eabi-g++ /usr/bin/arm-none-eabi-g++
+          sudo ln -s ./gcc-arm-none-eabi/bin/arm-none-eabi-gdb /usr/bin/arm-none-eabi-gdb
+          sudo ln -s ./gcc-arm-none-eabi/bin/arm-none-eabi-size /usr/bin/arm-none-eabi-size
+          sudo ln -s ./gcc-arm-none-eabi/bin/arm-none-eabi-objcopy /usr/bin/arm-none-eabi-objcopy
           arm-none-eabi-gcc --version
       - name: Install pico-sdk
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,17 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@main
+      - name: Bananas
+        uses: carlosperate/arm-none-eabi-gcc-action@v1
+      - name: Install arm-none-eabi-gcc
+        run: |
+          wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2
+          arm-none-eabi-gcc --version
+      - name: Install pico-sdk
+        run: |
+          git clone https://github.com/raspberrypi/pico-sdk --recurse-submodules
       - name: Build firmware
         run: |
-          sudo apt install -y arm-none-eabi-gcc
-          git clone https://github.com/raspberrypi/pico-sdk --recurse-submodules
           cd ./firmware
           mkdir build && cd build
           cmake .. -G Ninja -DPICO_SDK_PATH=../../pico-sdk

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,8 @@ jobs:
         uses: actions/checkout@main
       - name: Install arm-none-eabi-gcc
         run: |
-          wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2
+          wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2
+          mkdir gcc-arm-none-eabi
           sudo tar xjf gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 -C ./gcc-arm-none-eabi
           sudo ln -s ./gcc-arm-none-eabi/bin/arm-none-eabi-gcc /usr/bin/arm-none-eabi-gcc 
           sudo ln -s ./gcc-arm-none-eabi/bin/arm-none-eabi-g++ /usr/bin/arm-none-eabi-g++

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,8 +6,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - name: Bananas
-        uses: carlosperate/arm-none-eabi-gcc-action@v1
+      - name: Checkout
+        uses: actions/checkout@main
       - name: Install arm-none-eabi-gcc
         run: |
           wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,22 +8,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
-      - name: Install arm-none-eabi-gcc
-        run: |
-          wget --quiet https://developer.arm.com/-/media/Files/downloads/gnu-rm/10.3-2021.10/gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2
-          mkdir gcc-arm-none-eabi
-          sudo tar xjf gcc-arm-none-eabi-10.3-2021.10-x86_64-linux.tar.bz2 -C ./gcc-arm-none-eabi
-          sudo ln -s ./gcc-arm-none-eabi/bin/arm-none-eabi-gcc /usr/bin/arm-none-eabi-gcc 
-          sudo ln -s ./gcc-arm-none-eabi/bin/arm-none-eabi-g++ /usr/bin/arm-none-eabi-g++
-          sudo ln -s ./gcc-arm-none-eabi/bin/arm-none-eabi-gdb /usr/bin/arm-none-eabi-gdb
-          sudo ln -s ./gcc-arm-none-eabi/bin/arm-none-eabi-size /usr/bin/arm-none-eabi-size
-          sudo ln -s ./gcc-arm-none-eabi/bin/arm-none-eabi-objcopy /usr/bin/arm-none-eabi-objcopy
-          arm-none-eabi-gcc --version
-      - name: Install pico-sdk
+      - name: Clone pico-sdk dependency
         run: |
           git clone https://github.com/raspberrypi/pico-sdk --recurse-submodules
       - name: Build firmware
+        uses: carlosperate/arm-none-eabi-gcc-action@v1
         run: |
+          arm-none-eabi-gcc --version
           cd ./firmware
           mkdir build && cd build
           cmake .. -G Ninja -DPICO_SDK_PATH=../../pico-sdk

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build gbinterceptor
+name: Build gbinterceptor firmware
 on:
   push:
   pull_request:
@@ -8,6 +8,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@main
-      - name: Build
+      - name: Build firmware
         run: |
-          echo "Test"
+          pwd
+          ls -al
+          git clone https://github.com/raspberrypi/pico-sdk --recurse-submodules
+          cd ./firmware
+          mkdir build && cd build
+          cmake .. -G Ninja -DPICO_SDK_PATH=../../pico-sdk
+          ninja

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Clone pico-sdk dependency
         run: |
           git clone https://github.com/raspberrypi/pico-sdk --recurse-submodules
-          git reset --hard 2e6142b
+          cd pico-sdk && git reset --hard 2e6142b && cd ..
       - name: Build firmware
         run: |
           arm-none-eabi-gcc --version

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,3 +22,10 @@ jobs:
           mkdir build && cd build
           cmake .. -G Ninja -DPICO_SDK_PATH=../../pico-sdk
           ninja
+      - name: 'Upload artifacts'
+        uses: actions/upload-artifact@v3
+        with:
+          name: firmware
+          path: |
+            ./firmware/build/gb_interceptor.*
+          retention-days: 7

--- a/firmware/main.c
+++ b/firmware/main.c
@@ -5,7 +5,8 @@
 #include "pico/multicore.h"
 #include "pico/mutex.h"
 
-#include "bsp/board.h"
+#include "bsp/rp2040/board.h"
+#include "bsp/board_api.h"
 #include "tusb.h"
 #include "usb_descriptors.h"
 #include "hardware/clocks.h"


### PR DESCRIPTION
Hi,

I've followed the instructions in #3 to build the firmware myself.

The build was successful, however the compiled `.uf2` file is not binary identical with the released version even though it has been built from the same git commit as described here: https://github.com/Staacks/gbinterceptor/issues/3#issuecomment-1890746203

I suggest to let a GitHub Actions CI pipeline produce those builds automatically.

The problem is: the built `.uf2` produced by the CI pipeline (e.g. see artefcats in my fork https://github.com/maehw/gbinterceptor/actions/runs/7519559036) also does not run properly on the GB interceptor.

The build description may be missing a detail (is the pico-sdk version super-relevant?). How have the assets in https://github.com/Staacks/gbinterceptor/releases been built? How can we find out the relevant differences?

PS: Instead of accepting this PR, you could simply copy the `.github/workflows/main.yml` file. It may also be less dirty if I squashed all those trial-and-error commits into a single commit before merging.