### PR TITLE
Added GBC improvements

### DIFF
--- a/firmware/opcodes.c
+++ b/firmware/opcodes.c
@@ -9,6 +9,7 @@ bool syncArmed = false;
 uint statSyncStage = 0; //0 = false, 1 = register read to A, 2 = masked to 0x03, 3 = cp to 0x01
 uint lySyncStage = 0; //0 = false, 1 = register read, 2 = cp
 uint syncReferenceCycle;
+bool blockVRAMWrites; //0 = allow writes, 1 = block writes
 int syncOffset; //Helper to calculate offset to scanline for synching
 
 void setOffsetToLine(uint8_t line) {
@@ -63,6 +64,9 @@ void toMemory(uint16_t address, uint8_t data) {
 
     if ((address & 0xe000) == 0x8000) { //Writing to VRAM
         VRAM_HASH(address, data); //Calculate hash for game detection if we are writing to VRAM
+        // Block writes to GBC VRAM attribute map.
+        if (blockVRAMWrites)
+            return;
     } else if (address >= 0xff00) { //Handle some IO registers
         switch (address) {
             case 0xff04: //Reset DIV register
@@ -111,6 +115,11 @@ void toMemory(uint16_t address, uint8_t data) {
                 paletteOBP1[1] = ((~data >> 2) & 0x03);
                 paletteOBP1[2] = ((~data >> 4) & 0x03);
                 paletteOBP1[3] = ((~data >> 6) & 0x03);
+                break;
+            case 0xff4f: //VBK, GBC VRAM bank
+                // If VRAM bank 1 is selected, temporarily block all writes to VRAM to avoid glitches.
+                // We only care about bit 0.
+                blockVRAMWrites = data & 1;
                 break;
             case 0xff4d: //KEY1, GBC double speed mode switch
                 if (data & 0x01)

--- a/firmware/opcodes.h
+++ b/firmware/opcodes.h
@@ -6,4 +6,6 @@
 extern void (*opcodes[])();
 void toMemory(uint16_t address, uint8_t data);
 
+extern bool blockVRAMWrites;
+
 #endif

--- a/firmware/ppu.c
+++ b/firmware/ppu.c
@@ -1,6 +1,7 @@
 #include "ppu.h"
 
 #include "cpubus.h"
+#include "opcodes.h"
 #include "jpeg/jpeg.h"
 #include "debug.h"
 
@@ -92,6 +93,8 @@ void ppuInit() {
     interp_set_config(interp0, 1, &cfgUnmasked0);
     interp_set_config(interp1, 0, &cfgMasked1);
     interp_set_config(interp1, 1, &cfgUnmasked1);
+
+    blockVRAMWrites = 0;
 
     readyBufferIsNew = false;
     renderState = start;


### PR DESCRIPTION
Simple improvement for some GBC dual platform games that show glitches. Platforms before GBC don't have extended VRAM (bank 1) that holds attributes and extended tiles. Therefore, this fix detects writes to the VRAM bank select register, and if bank 1 is selected, writes to VRAM are blocked. This could make certain games that are meant for GBC run passably, enough to be streamed.

The scope of what this can fix is pretty narrow:

1. The game needs to have the issue for this patch to do anything in the first place. If it writes the attribute byte first, and then the tile index, it mostly won't have an issue because the glitchy attribute byte would be overwritten with the right value.
2. The game needs to run in single speed. (By definition, in order to work with the GBI.)
3. The game needs to not use any extended GBC functionality, like the attribute bits/extended tiles, and it needs to look ok with only monochrome palettes. (This is a somewhat subjective judgment of what looks ok.)
4. The game needs to set the DMG style background palettes, or you might end up with just a white screen or similar through the GBI. (This could be somewhat mitigated by setting default values for those registers.)

I think 1 is likely the most common way of doing it, so maybe many games won't be helped by this patch. 2 varies between games. 3 can vary as well, but has a good chance chance of being applicable if it's a dual platform title that has to have a support for DMG mode. 4 Might not always be true, if the game has separate code paths for monochrome and GBC. 

The risks that I can see with this solution are:

1. I don't know how much time headroom there is for extra code. Maybe the extra `if` is a problem in the worst case scenario? 
2. Maybe there are cases where games write incorrectly to `VBK (0xff4f)` while in DMG mode. This seems pretty unlikely though.

So far I've only tried it with Pokemon Gold/Silver which the original issue #36 was about.